### PR TITLE
Add support for CelebA test/train split

### DIFF
--- a/config.py
+++ b/config.py
@@ -22,6 +22,7 @@ net_arg.add_argument('--z_num', type=int, default=128)
 # Data
 data_arg = add_argument_group('Data')
 data_arg.add_argument('--dataset', type=str, default='CelebA')
+data_arg.add_argument('--split', type=str, default='train')
 data_arg.add_argument('--batch_size', type=int, default=16)
 data_arg.add_argument('--grayscale', type=str2bool, default=False)
 data_arg.add_argument('--num_worker', type=int, default=12)

--- a/data_loader.py
+++ b/data_loader.py
@@ -10,17 +10,19 @@ import torchvision.datasets as dset
 
 from folder import ImageFolder
 
-def get_loader(root, batch_size, scale_size, num_workers=2, shuffle=True):
+def get_loader(root, split, batch_size, scale_size, num_workers=2, shuffle=True):
     dataset_name = os.path.basename(root)
+    image_root = os.path.join(root, 'splits', split)
+
     if dataset_name in ['CelebA']:
-        dataset = ImageFolder(root=root, transform=transforms.Compose([
+        dataset = ImageFolder(root=image_root, transform=transforms.Compose([
             transforms.CenterCrop(160),
             transforms.Scale(scale_size),
             transforms.ToTensor(),
             #transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
         ]))
     else:
-        dataset = ImageFolder(root=root, transform=transforms.Compose([
+        dataset = ImageFolder(root=image_root, transform=transforms.Compose([
             transforms.Scale(scale_size),
             transforms.ToTensor(),
             #transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),

--- a/download.py
+++ b/download.py
@@ -47,6 +47,7 @@ def unzip(filepath):
 
 def download_celeb_a(base_path):
     data_path = os.path.join(base_path, 'CelebA')
+    images_path = os.path.join(data_path, 'images')
     if os.path.exists(data_path):
         print('[!] Found Celeb-A - skip')
         return
@@ -63,13 +64,53 @@ def download_celeb_a(base_path):
     with zipfile.ZipFile(save_path) as zf:
         zip_dir = zf.namelist()[0]
         zf.extractall(base_path)
-    os.rename(os.path.join(base_path, "img_align_celeba"), data_path)
+    if not os.path.exists(data_path):
+        os.mkdir(data_path)
+    os.rename(os.path.join(base_path, "img_align_celeba"), images_path)
     os.remove(save_path)
 
 def prepare_data_dir(path = './data'):
     if not os.path.exists(path):
         os.mkdir(path)
 
+# check, if file exists, make link
+def check_link(in_dir, basename, out_dir):
+    in_file = os.path.join(in_dir, basename)
+    if os.path.exists(in_file):
+        link_file = os.path.join(out_dir, basename)
+        rel_link = os.path.relpath(in_file, out_dir)
+        os.symlink(rel_link, link_file)
+
+def add_splits(base_path):
+    data_path = os.path.join(base_path, 'CelebA')
+    images_path = os.path.join(data_path, 'images')
+    train_dir = os.path.join(data_path, 'splits', 'train')
+    valid_dir = os.path.join(data_path, 'splits', 'valid')
+    test_dir = os.path.join(data_path, 'splits', 'test')
+    if not os.path.exists(train_dir):
+        os.makedirs(train_dir)
+    if not os.path.exists(valid_dir):
+        os.makedirs(valid_dir)
+    if not os.path.exists(test_dir):
+        os.makedirs(test_dir)
+
+    # these constants based on the standard CelebA splits
+    NUM_EXAMPLES = 202599
+    TRAIN_STOP = 162770
+    VALID_STOP = 182637
+
+    for i in range(0, TRAIN_STOP):
+        basename = "{:06d}.jpg".format(i+1)
+        check_link(images_path, basename, train_dir)
+    for i in range(TRAIN_STOP, VALID_STOP):
+        basename = "{:06d}.jpg".format(i+1)
+        check_link(images_path, basename, valid_dir)
+    for i in range(VALID_STOP, NUM_EXAMPLES):
+        basename = "{:06d}.jpg".format(i+1)
+        check_link(images_path, basename, test_dir)
+
 if __name__ == '__main__':
+    base_path = './data'
     prepare_data_dir()
-    download_celeb_a('./data')
+    download_celeb_a(base_path)
+    add_splits(base_path)

--- a/folder.py
+++ b/folder.py
@@ -35,6 +35,8 @@ class ImageFolder(data.Dataset):
             raise(RuntimeError("Found 0 images in subfolders of: " + root + "\n"
                                "Supported image extensions are: " + ",".join(IMG_EXTENSIONS)))
 
+        print("Found {} images in subfolders of: {}".format(len(imgs), root))
+
         self.root = root
         self.imgs = imgs
         self.transform = transform

--- a/main.py
+++ b/main.py
@@ -23,7 +23,7 @@ def main(config):
         batch_size = config.sample_per_image
 
     data_loader = get_loader(
-        data_path, batch_size, config.input_scale_size, config.num_worker)
+        data_path, config.split, batch_size, config.input_scale_size, config.num_worker)
 
     trainer = Trainer(config, data_loader)
 


### PR DESCRIPTION
The current training routine is using all of the CelebA
images, including the canonical CelebA validation and
test data. This change adds support for CelebA splits
and by default only trains on only the CelebA training
images.

This was done by moving the downloaded data into an
"images" subdirectory, and then creating subdirectories
of splits with relative symlinks to the original files.
This format required only light changes to the config
and data_loader.

Note that honoring the standard splits in generative
modeling is important for a few reasons. Perhaps most
importantly, it allows for fair comparisons across papers
when visually inspecting image samples; it is unfair
to compare models trained on 200k images versus those
only exposed to a 160k subset. But also relevant for
models with an encoder like BEGAN - it allows one to
evaluate a trained model by performing reconstructions
on out of sample validation data.