### PR TITLE
Added autoencoded image output when run in test mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To train a model:
 
 To test a model (use your `load_path`):
 
-    $ python main.py --dataset=CelebA --load_path=logs/CelebA_0404_105537 --num_gpu=0 --is_train=False
+    $ python main.py --dataset=CelebA --load_path=./logs/CelebA_0405_124806 --num_gpu=0 --is_train=False --split valid
 
 
 ## Results

--- a/folder.py
+++ b/folder.py
@@ -15,7 +15,7 @@ def is_image_file(filename):
 def make_dataset(dir):
     images = []
     for root, _, fnames in sorted(os.walk(dir)):
-        for fname in fnames:
+        for fname in sorted(fnames):
             if is_image_file(fname):
                 path = os.path.join(root, fname)
                 item = (path, 0)

--- a/main.py
+++ b/main.py
@@ -15,15 +15,17 @@ def main(config):
     if config.is_train:
         data_path = config.data_path
         batch_size = config.batch_size
+        do_shuffle = True
     else:
         if config.test_data_path is None:
             data_path = config.data_path
         else:
             data_path = config.test_data_path
         batch_size = config.sample_per_image
+        do_shuffle = False
 
     data_loader = get_loader(
-        data_path, config.split, batch_size, config.input_scale_size, config.num_worker)
+        data_path, config.split, batch_size, config.input_scale_size, config.num_worker, do_shuffle)
 
     trainer = Trainer(config, data_loader)
 

--- a/trainer.py
+++ b/trainer.py
@@ -234,7 +234,10 @@ class Trainer(object):
             print("[*] Samples saved: {}".format(x_fake_path))
 
     def test(self):
-        pass
+        data_loader = iter(self.data_loader)
+        x_fixed = self._get_variable(next(data_loader))
+        vutils.save_image(x_fixed.data, '{}/x_fixed_test.png'.format(self.model_dir))
+        self.autoencode(x_fixed, self.model_dir, idx="test", x_fake=None)
 
     def save_model(self, step):
         print("[*] Save models to {}...".format(self.model_dir))


### PR DESCRIPTION
Running in test mode was not producing any output, so I added
an initial implementation of Trainer.test(). This simply
autoencodes a batch of inputs, and saves the inputs
as well as the autoencoded outputs.

This can be combined with '--split valid' to test
autoencoding on validation data. To make these tests
more repeatable, shuffling was disabled in test
mode and the images are sort ordered.

Sample output attached.
![validation inputs](https://cloud.githubusercontent.com/assets/945979/24690364/881ff7ce-1a20-11e7-9639-0661c25ad782.png)
![autoencoded](https://cloud.githubusercontent.com/assets/945979/24690368/8d6c22e8-1a20-11e7-84ee-be866f102caf.png)

